### PR TITLE
Pass the issue to the hook when viewing time entries grouped by issue.

### DIFF
--- a/app/views/timesheet/_issue_time_entries.rhtml
+++ b/app/views/timesheet/_issue_time_entries.rhtml
@@ -20,7 +20,7 @@
       </div>
     </td>
     <td align="center"><strong><%= number_with_precision(displayed_time_entries_for_issue(time_entries), @precision) %></strong></td>
-    <%= Redmine::Hook.call_hook(:plugin_timesheet_views_timesheet_time_entry_sum, {:time_entries => time_entries, :precision => @precision }) %>
+    <%= Redmine::Hook.call_hook(:plugin_timesheet_views_timesheet_time_entry_sum, {:issue => issue, :time_entries => time_entries, :precision => @precision }) %>
     <td align="center"></td>
   </tr>
 <% time_entries.each do |time_entry| %>


### PR DESCRIPTION
This makes it more convenient to get access the issue, without resorting to weird constructs like context[:time_entries].first.issue
